### PR TITLE
Moving requirements list into setup.py

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,1 @@
-tqdm
-nltk
-petl
-numpy
-pandas
-tweepy
-mailbox
-gitpython
-sphinx_rtd_theme
+.

--- a/setup.py
+++ b/setup.py
@@ -27,21 +27,24 @@ import pip
 from os import path
 from codecs import open
 from setuptools import setup, find_packages
-from pip.req import parse_requirements
+
+INSTALL_REQS = [
+    'tqdm',
+    'nltk',
+    'petl',
+    'numpy',
+    'pandas',
+    'tweepy',
+    'mailbox',
+    'gitpython',
+    'sphinx_rtd_theme',
+]
 
 
 here = path.abspath(path.dirname(__file__))
 
 # !!! Update version here!
 version_string = '0.3.4'
-
-# Parse requirements
-# parse_requirements() returns generator of pip.req.InstallRequirement objects
-install_reqs = parse_requirements('requirements.txt', session=pip.download.PipSession())
-
-# reqs is a list of requirement
-# e.g. ['django==1.5.1', 'mezzanine==1.4.6']
-reqs = [str(ir.req) for ir in install_reqs]
 
 # Get the long description from the README file
 with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
@@ -104,7 +107,7 @@ setup(
     # your project is installed. For an analysis of "install_requires" vs pip's
     # requirements files see:
     # https://packaging.python.org/en/latest/requirements.html
-    install_requires=reqs,
+    install_requires=INSTALL_REQS,
 
     # List additional groups of dependencies here (e.g. development
     # dependencies). You can install these using the following syntax,


### PR DESCRIPTION
Currently pip install tidyextractors fails because pip has deprecated
pip.req module. The recommended approach is now to put the requirements
directly into setup.py and leave '.' in the requirements so others can
still run "pip install -r requirements.txt"

Reference: https://stackoverflow.com/questions/49689880/proper-way-to-parse-requirements-file-after-pip-upgrade-to-pip-10-x-x